### PR TITLE
Fix image path

### DIFF
--- a/docs/consensus/proof_of_space.md
+++ b/docs/consensus/proof_of_space.md
@@ -20,10 +20,10 @@ This specification defines a secure proof-of-space construction for [Plotting](p
 - `k`: a global memory requirement parameter, currently 20
 - `seed`: a unique 32-byte seed that determines memory contents (the table values) obtained from the farmer public key, current sector, piece offset within the sector and current history size.
 - `PARAM_EXT`: a PRNG extension parameter to avoid collisions, currently 6
-- `PARAM_M = 1 << PARAM_EXT = 64` matching function parameter 
-- `PARAM_B = 119`  matching function parameter 
-- `PARAM_C = 127`  matching function parameter 
-- `PARAM_BC = PARAM_B * PARAM_C`  matching function parameter 
+- `PARAM_M = 1 << PARAM_EXT = 64` matching function parameter
+- `PARAM_B = 119`  matching function parameter
+- `PARAM_C = 127`  matching function parameter
+- `PARAM_BC = PARAM_B * PARAM_C`  matching function parameter
 
 ## Table Generation
 
@@ -61,7 +61,7 @@ Computes the 7 PoS tables.
 
 1. Compute the first table `t_1 = compute_table1(k, seed)` and push to `pos_tables`.
 2. Compute each of `t_2, …, t_7`, as follows, by `table_number`.
-3. Take the previous table (`table_number-1`). 
+3. Take the previous table (`table_number-1`).
 4. For each `entry`, separate the `y` values from the table entry into buckets (see illustration) in a sliding manner:
     1. Define two vectors of entries to hold two buckets of our sliding pair `left_bucket` and `right_bucket`. If this is not the first time we run this loop (we are not at the beginning of the table), set the current `left_bucket` to the previous `right_bucket` and continue.
     Otherwise:
@@ -79,11 +79,11 @@ Computes the 7 PoS tables.
         - `chiapos` sorts the table by `y`, so the order may differ in our implementation.
         - `chiapos` uses k-way merge to deal with the fact that table might be too large to store in memory. Since we don’t have this problem we could use a faster algorithm.
         </Collapsible>
-            
+
 
 The resulting `pos_tables` is a vector containing the 7 tables in order.
 
-![Steps 4.ii-iv in generate function definition. Numbers and matching function $M$ are solely illustrative. Since the `entry.y` is sorted, Chia does this sequentially on portions of the table as their tables don’t fit in memory.  Notice that 235 and 380 appear in multiple matches, while some numbers don’t have a match.](/img/Proof_of_space_plotting.png)
+![Steps 4.ii-iv in generate function definition. Numbers and matching function $M$ are solely illustrative. Since the `entry.y` is sorted, Chia does this sequentially on portions of the table as their tables don’t fit in memory.  Notice that 235 and 380 appear in multiple matches, while some numbers don’t have a match.](/static/img/Proof_of_space_plotting.png)
 
 <center>Steps 4.ii-iv in generate function definition. Numbers and matching function $M$ are solely illustrative. Since the `entry.y` is sorted, Chia does this sequentially on portions of the table as their tables don’t fit in memory.  Notice that 235 and 380 appear in multiple matches, while some numbers don’t have a match.</center>
 
@@ -99,15 +99,15 @@ Computes the whole table `t_1` for all values of `x in 0..2^k`:
 1. Initialize ChaCha8 stream PRNG with the given seed  `ChaCha8(seed, 0)`.
 2. Generate `k*2^k` bits of PRNG output. Slice it into `2^k` `fx` values. The output for `x=0` will be the first `k` bits, the output of `x=1` will be the next `k` bits, and so on.
 3. Append to each `y` the `PARAM_EXT` most significant bits of the corresponding `x`.
-4. Push `(y, x)` pairs to `t_1`. 
-5. Sort `t_1` by `y`. 
+4. Push `(y, x)` pairs to `t_1`.
+5. Sort `t_1` by `y`.
 
 <Collapsible title="Note">
 - Consider this function a necessary optimization of `compute_f1` It is much faster to generate the whole result of `f1(0..2^k)` in one go due to the stream nature of ChaCha instead of computing one by one. chiapos does in batches, since the whole table is too big in their case
 - The output is extended by `PARAM_EXT` (6) bits, so `f1(x)` takes `x` of k bits as input and outputs y of `k + 6` bits. These 6 bits are the most significant bits of x, added to minimize collisions (birthday paradox).
 - Sorting is needed to optimize bucketing for `find_matches` in the calculation of the next table
 </Collapsible>
-   
+
 
 ### compute_f1
 
@@ -131,10 +131,10 @@ The output `y` has length `k+PARAM_EXT` bits.
 
 `compute_fn(table_number, y_in, left, right) → (y, metadata)`
 
-1. Compute BLAKE3 hash `hash = Hash(y_in || left || right)` 
+1. Compute BLAKE3 hash `hash = Hash(y_in || left || right)`
 2. `y` is `hash` truncated to `k + PARAM_EXT` bits
 3. If `table_number < 4` set `metadata = left || right`
-4. If `table_number >= 4` set `metadata` to `hash` bits `[k+PARAM_EXT .. k+PARAM_EXT + metadata_size_bits(table_number)]` 
+4. If `table_number >= 4` set `metadata` to `hash` bits `[k+PARAM_EXT .. k+PARAM_EXT + metadata_size_bits(table_number)]`
 
 ### metadata_size_bits
 
@@ -144,21 +144,21 @@ Size of collation metadata corresponding to each table. Extra bits are added to 
 ```rust
 k * match table_number {
 
- 1 => 1, 
+ 1 => 1,
  2 => 2,
  3 | 4 => 4,
  5 => 3,
  6 => 2,
- 7 => 0 
+ 7 => 0
     }
 ```
 ## Matching Functions
 
 The matching functions define whether two entries in a table match according to two conditions.
 
-The first condition is that the 2 candidate entries belong to adjacent buckets. 
+The first condition is that the 2 candidate entries belong to adjacent buckets.
 
-The second condition is quite complex. 
+The second condition is quite complex.
 
 Consider an underlying graph of a table: the digraph where each node is an entry, and
 an edge exists if that pair of entries is a match. The second condition defines the edges of this graph for parameters `PARAM_B` and `PARAM_C`. Each node (entry) of this graph is described with a triplet $(i,b,c)$ for $i\in\Z$ (the bucket id of the entry), $b \in \Z_{PARAM\_B}$ (entry remainder modulo `PARAM_B`) and $c \in\Z_{PARAM\_C}$ (entry remainder modulo `PARAM_C`). The edges in the graph are given between two nodes as:
@@ -167,7 +167,7 @@ an edge exists if that pair of entries is a match. The second condition defines 
 
 for all 0 ≤ $m$ < 64 = `PARAM_M`
 
-The second condition avoids cycles between inputs if the set is represented as a graph. These cycles can be compressed by saving fewer entries and deriving the rest, representing a potential attack because it would optimize storage (see Cycles Attack in [Chia Proof-of-Space Construction v1.1-1](https://www.chia.net/wp-content/uploads/2022/09/Chia_Proof_of_Space_Construction_v1.1-1.pdf)). This is also why `PARAM_B = 119` and `PARAM_C = 127` have those values. 
+The second condition avoids cycles between inputs if the set is represented as a graph. These cycles can be compressed by saving fewer entries and deriving the rest, representing a potential attack because it would optimize storage (see Cycles Attack in [Chia Proof-of-Space Construction v1.1-1](https://www.chia.net/wp-content/uploads/2022/09/Chia_Proof_of_Space_Construction_v1.1-1.pdf)). This is also why `PARAM_B = 119` and `PARAM_C = 127` have those values.
 
 ### get_left_targets
 
@@ -188,7 +188,7 @@ Compute possible target matching values `left_targets` for use in `find_matches`
 
 `find_matches(left_bucket, right_bucket)` → `vec((left_index, right_index))`
 
-Given two buckets with entries (`y` values), computes which `y` values match and returns a list of the pairs of indices `(left_index, right_index)` into `left_bucket` and `right_bucket`. 
+Given two buckets with entries (`y` values), computes which `y` values match and returns a list of the pairs of indices `(left_index, right_index)` into `left_bucket` and `right_bucket`.
 
 <Collapsible title="Note">
 Instead of doing naive pair-wise comparison in $$O(N^2)$$ we first compute the target values needed to match based on left bucket, then scan the right bucket
@@ -202,16 +202,16 @@ Instead of doing naive pair-wise comparison in $$O(N^2)$$ we first compute the t
     <Collapsible title="Note">
     `y` is not unique, so multiple `right_index` can match the same `rmap[r]`, but they will all be next to each other, so it is possible to store start index and count rather than dynamically sized vector of indices.
     </Collapsible>
-    
+
 2. Calculate the `parity` (0 or 1) of the first entry in `left_bucket` as `(left_bucket[0].y/PARAM_BC)%2`.
 3. Iterate over entries in `left_bucket` with `left_index` being the index of the corresponding entry.
     1. Reduce each entry value to the remainder of its division by `PARAM_BC`. To do so, compute `l_base = r_base - PARAM_BC` and subtract it from each entry’s `fx` in the left bucket to get `r = entry.y - l_base`.
-        
+
         For each `left_bucket` entry `m`, set a target value `r_target` as `left_targets[parity][r][m]`
-        
-    
+
+
     Check `rmap[r_target]` for right indices and collect into pairs of `(left_index, right_index)`.
-    
+
 4. Return the list of all matching pairs.
 
 ## Find Quality
@@ -239,10 +239,10 @@ For a given `challenge` , sample the `pos_table` for a *proof-of-space quality s
 4. For the matching `entry` in `t_7`, iterate backward over tables `t_6 .. t_2` and backward over `last_five_bits`:
     1. If the corresponding bit in `last_five_bits` is 0, read the new `entry` in the current table at the position `entry.left_position`
     2. Else if the corresponding bit in `last_five_bits` is 1, read the new `entry` in the current table at the position `entry.right_position`
-    3. Perform the same read in the previous table for the newly found `entry` 
+    3. Perform the same read in the previous table for the newly found `entry`
 5. After step 3 finishes by reaching the second table `t_2`, read 2 entries in the first table:
     1. Read the `left_entry` in `t_1` at the position `entry.left_position`
-    2. Read the `right_entry` in `t_1` at the position `entry.right_position` 
+    2. Read the `right_entry` in `t_1` at the position `entry.right_position`
     3. Add the left and right entries to the `quality_entries` vector.
 6. For the two `entry` in `quality_entries`, take `entry.x` truncated to `k` bits and concatenate them together.
 7. Output the 32-byte SHA256 hash of `challenge || left_entry.x || right_entry.x` .
@@ -254,9 +254,9 @@ For a given `challenge` , sample the `pos_table` for a *proof-of-space quality s
 
 ## Proving
 
-A *proof-of-space* for a given `challenge` is a set of 64 `k`-bit entries of table `t_1`. 
+A *proof-of-space* for a given `challenge` is a set of 64 `k`-bit entries of table `t_1`.
 
-To find proof, we must see if table `t_7` has one or more entries `entry.y` values where the first `k` bits match the first `k` bits of the `challenge`. 
+To find proof, we must see if table `t_7` has one or more entries `entry.y` values where the first `k` bits match the first `k` bits of the `challenge`.
 Each satisfying entry in the last table, `t_7`, points to 2 entries in table `t_6`. These two entries will point to 2 entries in table `t_5` and so on up to table 1. So an entry in the last table will indirectly point to 64 entries in the first table ($2^{7−1}$ ). These 64 entries concatenated are the *proof-of-space*.
 
 ### find_proof
@@ -273,16 +273,16 @@ For a given `challenge`, query the `pos_table` for a valid full *proof-of-space*
     - Read the `right_entry` in the current table at the position `entry.right_position`
     - Add the left and right entries to the `entries_buffer` vector.
     - Perform the same read in the previous table for each newly found entry in the buffer.
-4. After step 3 finishes by reading all required entries from the first table `t_1`, the `entries_buffer` should have 64 entries. 
+4. After step 3 finishes by reading all required entries from the first table `t_1`, the `entries_buffer` should have 64 entries.
 5. For each `entry` in `entries_buffer`, take the corresponding `entry.x` and concatenate them together.
 
 ## Verification
 
-Verification of the 64-point proof-of-space is performed by evaluating the table functions `f1..fn` on each `x` in the proof and checking whether they satisfy the matching function at each step. 
+Verification of the 64-point proof-of-space is performed by evaluating the table functions `f1..fn` on each `x` in the proof and checking whether they satisfy the matching function at each step.
 
-To verify a proof-of-space, we need 4 things: the 64 x values in the `proof_of_space`, the parameter `k`, the `seed`, and the `challenge_index`. The process is more or less the same as table generation, i.e., we compute the same functions but do not generate the entire tables, only a tiny subset. Only the outputs for the x values of the proof are calculated to be able to verify that: 
+To verify a proof-of-space, we need 4 things: the 64 x values in the `proof_of_space`, the parameter `k`, the `seed`, and the `challenge_index`. The process is more or less the same as table generation, i.e., we compute the same functions but do not generate the entire tables, only a tiny subset. Only the outputs for the x values of the proof are calculated to be able to verify that:
 
-1. the outputs `f1..f7` satisfy the matching function at each step, 
+1. the outputs `f1..f7` satisfy the matching function at each step,
 2. the final output `fn` of table `t_7` corresponds to the `challenge_index`.
 
 Consider an example with four tables. The proof-of-space then consists of $2^{(4-1)} = 8$ values $x_1||…||x_8$. The verifier will perform the following:
@@ -291,7 +291,7 @@ Consider an example with four tables. The proof-of-space then consists of $2^{(4
 
 <center>$$f_1(x_1), f_1(x_2), f_1(x_3), f_1(x_4), f_1(x_5), f_1(x_6), f_1(x_7), f_1(x_8)$$</center>
 
-2. Verify that the matching function $M$ returns a match on each of the following four pairs 
+2. Verify that the matching function $M$ returns a match on each of the following four pairs
 
 <center>$$M(f_1(x_1), f_1(x_2)), M(f_1(x_3), f_1(x_4)), M(f_1(x_5), f_1(x_6)), M(f_1(x_7), f_1(x_8))$$</center>
 
@@ -299,13 +299,13 @@ Consider an example with four tables. The proof-of-space then consists of $2^{(4
 
 <center>$$f_2(x_1, x_2), f_2(x_3, x_4), f_2(x_5, x_6), f_2(x_7, x_8)$$</center>
 
-4. Verify the matching function $M$ returns a match on each of the following two pairs 
+4. Verify the matching function $M$ returns a match on each of the following two pairs
 <center>$$M(f_2(x_1, x_2), f_2(x_3, x_4)), M(f_2(x_5, x_6), f_2(x_7, x_8))$$</center>
 
 5. Compute the outputs of the third table function $f_3(x)$:
 <center>$$f_3((x_1, x_2), (x_3, x_4)), f_3((x_5, x_6), (x_7, x_8))$$</center>
 
-6. Verify the matching function $M$ returns a match 
+6. Verify the matching function $M$ returns a match
 <center>$$M(f_3((x_1, x_2), (x_3, x_4)), f_3((x_5, x_6), (x_7, x_8)))$$</center>
 
 7. Compute the last table value
@@ -321,7 +321,7 @@ Verifies whether *proof-of-space* `proof_of_space` is valid for the `challenge` 
 
 1. Split `proof_of_space` into `k`-bit `x_values`. Check that `x_values` has length 64.
 2. Set 2 empty vectors for `y_values` and `metadata`.
-3. For each `x` in `x_values`: 
+3. For each `x` in `x_values`:
     1. Calculate the `(y, x) = compute_f1(x)` value for each x, and add the `y` value and `x` metadata to the `y_values` and `metadata` vectors, respectively.
 4. Iterate over table numbers `2..=7`:
     1. Iterate over `y_values` and `metadata` in steps of 2 (for left and right entries)

--- a/docs/consensus/proof_of_time.md
+++ b/docs/consensus/proof_of_time.md
@@ -27,7 +27,7 @@ A Node or Consensus Node (unless otherwise noted as Timekeeper) is a PoT client 
 
 ## Primitives
 
-We construct a PoT function by iterating AES-128 a large number of times. The prover evaluation latency for the fastest available hardware platform is calculated as the number of iterations times the latency for a single iteration of AES-128 on that hardware platform. We may then tune the number of iterations based on the lowest-latency hardware platform at the time to guarantee the minimum wall-clock time required for anyone to evaluate the PoT. 
+We construct a PoT function by iterating AES-128 a large number of times. The prover evaluation latency for the fastest available hardware platform is calculated as the number of iterations times the latency for a single iteration of AES-128 on that hardware platform. We may then tune the number of iterations based on the lowest-latency hardware platform at the time to guarantee the minimum wall-clock time required for anyone to evaluate the PoT.
 
 ## Public Constants
 
@@ -37,7 +37,7 @@ We construct a PoT function by iterating AES-128 a large number of times. The pr
 <Collapsible title="Note">
 This parameter is $c$ in security analysis.
 </Collapsible>
-        
+
 - `POT_ENTROPY_INJECTION_LOOKBACK_DEPTH`: depth at which the injected block is taken, measured in multiples of `POT_ENTROPY_INJECTION_INTERVAL`s, currently `2` *(equal to 100 blocks, the archiving depth)*
 - `POT_ENTROPY_INJECTION_DELAY`: number of slots between when the injection condition is met at slot `t` and when the injection into the PoT chain happens at slot `t + POT_ENTROPY_INJECTION_DELAY`, currently equal to 15 slots
 - `NUM_CHECKPOINTS`: number of checkpoint values for the proof-of-time verification published in 1 slot, currently 8
@@ -65,8 +65,8 @@ Takes a `seed` and number of iterations `pot_iterations` and repeatedly evaluate
 
 <div align="center">
 
-![Proof of Time Light](/img/Proof_of_Time_light.svg#gh-light-mode-only)
-![Proof of Time Dark](/img/Proof_of_Time_dark.svg#gh-dark-mode-only)
+![Proof of Time Light](/static/img/Proof_of_Time_light.svg#gh-light-mode-only)
+![Proof of Time Dark](/static/img/Proof_of_Time_dark.svg#gh-dark-mode-only)
 
 
 </div>
@@ -98,10 +98,10 @@ Verifies that the `proof_of_time` was computed correctly for `pot_iterations` nu
 3. Set `key = hash(seed)`
 4. Iterate through `checkpoints` in `proof_of_time` in steps of 2. The first checkpoint is `seed`.
 5. For each pair of `checkpoints[i]` and `checkpoints[i+1]`run:
-    
-    
-    ![Subspace v2 Master - Consensus (2).png](/img/PoT_Verification.png)
-    
+
+
+    ![Subspace v2 Master - Consensus (2).png](/static/img/PoT_Verification.png)
+
     1. Loop evaluation of `aes_encrypt(key, checkpoints[i])` encryption routine for `checkpoint_iterations/2` iterations.
     2. Loop evaluation of `aes_decrypt(key, checkpoint[i+1])` decryption routine for `checkpoint_iterations/2` iterations.
 6. If all pairs are correct, return `True`, otherwise, return `False`
@@ -124,7 +124,7 @@ There are three ways a node may get the proofs to extend its local view of the P
 - [Evaluation](#evaluation): Proofs computed locally (common case for Timekeepers)
 1. When a node comes online (for the first time or otherwise), it should perform a major sync of the consensus chain ([Consensus Chain sync](#consensus-chain-sync)), if needed (if the best block tip is behind the chain tip), and get the latest “committed” PoT from the newest block header.
 2. If the node previously held a local view of the PoT tree, which is no longer consistent with the PoT synced consensus chain (i.e., proofs are outdated or orphaned), discard the outdated view and reorg the tip of the PoT chain and restart Timekeeper to build on top of this new tip.
-3. Listen to gossip for PoT messages newer than the last PoT included on the consensus chain. 
+3. Listen to gossip for PoT messages newer than the last PoT included on the consensus chain.
 4. Process the received gossip PoT proofs and extend the local PoT chain with each new slot proof verified as per [PoT Gossip Processing](#pot-gossip-processing).
 5. As soon as local best proof is up-to-date with observed gossip, Timekeepers should start evaluating on top of it.
 6. The `slot_number` in the best valid proof known to this node becomes the tip of the PoT chain in the view of this node for all intents and purposes.
@@ -136,7 +136,7 @@ When Chain reorg happens or when the new potential tip is received via Gossip, T
 
 ## Timekeeper Algorithms
 
-Timekeepers run PoT evaluation for a specified number of iterations for the next slot from the `best_proof` at each time slot. The `best_proof` is the latest PoT value considered valid by this Timekeeper. 
+Timekeepers run PoT evaluation for a specified number of iterations for the next slot from the `best_proof` at each time slot. The `best_proof` is the latest PoT value considered valid by this Timekeeper.
 
 ### Slot Inputs
 
@@ -159,7 +159,7 @@ For subsequent slots (with `slot_number > 0`), there are two cases for seed valu
 
 ### Slot Iterations
 
-Each slot requires `pot_slot_iterations` defined in the genesis config. 
+Each slot requires `pot_slot_iterations` defined in the genesis config.
 
 Occasionally, we may update the number of iterations per slot, which will take effect at the nearest injection slot. All subsequent slots will be evaluated and verified with respect to the updated number of iterations.
 
@@ -169,7 +169,7 @@ Occasionally, we may update the number of iterations per slot, which will take e
 2. Gossip the `ProofOfTime:{slot_number, seed, pot_slot_iterations, checkpoints}`  ([definition](#pot-gossipping)) to other nodes.
 
 
-![Subspace v2 Master - Consensus.png](/img/PoT_Evaluation.png)
+![Subspace v2 Master - Consensus.png](/static/img/PoT_Evaluation.png)
 
 
 Note for [Randomness Updates](proof_of_archival_storage.md#randomness-updates): The `global_randomness` that farmers will use for the slot `next_slot` is computed as `derive_global_randomness(new_proof_of_time.output())`
@@ -180,7 +180,7 @@ Entropy from the consensus chain is injected into the PoT chain every `POT_ENTRO
 
 1. **Entropy Sourcing**
     1. For every block where `block_number % POT_ENTROPY_INJECTION_INTERVAL == 0`, derive entropy as `entropy = hash(chunk || proof_of_time)`, where `chunk` is the winning PoS solution chunk and `proof_of_time` is the PoT output of the slot claimed by this block.
-    2. Store the `entropy` associated with `block_number` and undefined (for now) future `injection_slot` at which it will be injected into the PoT chain. 
+    2. Store the `entropy` associated with `block_number` and undefined (for now) future `injection_slot` at which it will be injected into the PoT chain.
 2. **Setting Injection Slot**
     1. Set `injection_slot = slot + POT_INJECTION_DELAY` for entropy entry associated with block `block_number - POT_ENTROPY_INJECTION_INTERVAL * POT_ENTROPY_INJECTION_LOOKBACK_DEPTH`, where `slot` corresponds to the slot claimed by current block  `block_number`.
     2. If no such entry exists because the subtraction from `block_number` underflows or hits genesis block number 0), no injection needs to be done.
@@ -229,7 +229,7 @@ Upon receiving a new gossiped proof `proof_of_time`, all up-to-date nodes:
 5. If the node doesn’t have a valid PoT for `slot_number-1`, they should save the `proof_of_time` in a tree and wait until they receive and verify the previous PoTs before proceeding.
 6. If the node already has a valid PoT for `slot_number-1`, they can verify the received proofs for `slot_number`:
     1. For all proofs for this slot, verify that the slot inputs (`seed` and `slot_iterations`) match the expected as defined in [Slot Inputs](#slot-inputs) accounting for eventual injection and iteration updates if necessary. Discard the proofs with incorrect inputs.
-    2. Let `num_proofs` be the number of proofs remaining for this slot after the input check. 
+    2. Let `num_proofs` be the number of proofs remaining for this slot after the input check.
     3. If `num_proofs < EXPECTED_POT_VERIFICATION_SPEEDUP`, attempt to find the correct proof by verifying the checkpoints were computed correctly with `verify(seed, slot_iterations, checkpoints)` for each proof, starting with proofs sent by most reputable peer.
         1. If a proof validates successfully, forward PoT message to their peers and proceed with the audit and solving.
         2. Ban the peers who sent all other proofs.
@@ -243,11 +243,11 @@ Upon receiving a new gossiped proof `proof_of_time`, all up-to-date nodes:
 2. For every `slot_number` farmer audits their plot as described in [Audit](proof_of_archival_storage.md#audit) for potential solutions for all as far into the future as revealed randomness allows based on the global randomness they have received from the node so far.
 3. If they win a challenge, they start solving and proving it, as described in [Proving](proof_of_archival_storage.md#proving), to later claim the slot and produce a block with the precomputed solution.
 4. In the block, the farmer should include the output of proof-of-time at the slot they claim for verifiability.
-    
+
     To keep the header minimal size, only the outputs of claimed slot `x` and `x + BLOCK_AUTHORING_DELAY` are included in block header pre-digest items. The output of claimed slot `x` is sufficient to verify PoS solution.
-    
+
     The `BLOCK_AUTHORING_DELAY` is required to make sure faster farmers (farmers that can produce PoS faster due to faster SSD and/or CPU) do not get advantage in the race to produce a block.
-    
+
     All checkpoints of all slots passed since the parent block’s future proof of time (if any) up to `slot_number + BLOCK_AUTHORING_DELAY` of current block are included in [justifications](https://substrate-developer-hub.github.io/rustdocs/latest/sp_runtime/generic/struct.SignedBlock.html) to allow more parallelism during PoT verification. Essentially all checkpoints that were not yet seen on chain must be included and subsequently archived as part of the block.
 
 ## Consensus Chain sync
@@ -272,14 +272,14 @@ Depending on how far `block_number` is from the `target` we define a few thresho
 1. For `diff ≤ 1581` blocks, return `true` to verify all blocks
 2. for `diff ≤ 6234` blocks, verify `sample_size = 1581` blocks
 3. for `diff ≤ 63240` blocks, verify `sample_size = 3162*(diff-3162)/(diff-1)` blocks
-4. for `diff ≤ 3 162 000` blocks, verify `sample_size = 3162` blocks 
+4. for `diff ≤ 3 162 000` blocks, verify `sample_size = 3162` blocks
 5. for `diff > 3 162 000` blocks, verify `sample_size = diff/1000` blocks
 
-Generate a random number `n` in the range `0..=(diff)` and if `n<sample_size` return `true`, otherwise return `false`. 
+Generate a random number `n` in the range `0..=(diff)` and if `n<sample_size` return `true`, otherwise return `false`.
 
 <Collapsible title="Explanation">
     Base sample size computed as $n=\frac{Z^2\ p\ (1−p)}{E^2}$, where $Z$ is the $Z$-score, which is 2.58 for a 99% confidence level, $*p*$ is the expected proportion of correct proofs 0.95, $E$ is the margin of error, which is 0.01 for 1% results in $n=3162$ under the assumption of infinitely large population $N$ (number of blocks to sync). However, quite often that is not the case, so we have to adjust the sample size for each of the bins. Usually that is done via finite population correction $FPC = \sqrt\frac{N-n}{N-1}$ and $n'=n*FPC^2$, however that doesn’t help in cases  $N\approx n$ and $N<n$
-    
+
     To simplify the implementation, I define the following bins with boundaries that personally make sense:
 
     - for $N≤1581$, verify all blocks as they are recent enough (~2.5 hrs) and may also have checkpoints available
@@ -290,14 +290,14 @@ Generate a random number `n` in the range `0..=(diff)` and if `n<sample_size` re
 
     Here’s a plot of verification probability of each block until example target 500 000 (Sep 19 2023 Gemini3f)
 
-    ![PoT_Explanation_SC_1.png](/img/PoT_Explanation_SC_1.png) 
+    ![PoT_Explanation_SC_1.png](/static/img/PoT_Explanation_SC_1.png)
 
 
     Close-up to last 15k blocks
 
-    ![PoT_Explanation_SC_2.png](/img/PoT_Explanation_SC_2.png)
+    ![PoT_Explanation_SC_2.png](/static/img/PoT_Explanation_SC_2.png)
 
-    
+
 </Collapsible>
 
 

--- a/docs/crypto_primitives.md
+++ b/docs/crypto_primitives.md
@@ -20,7 +20,7 @@ Hashes provide succinct commitments to arbitrary data.
 
 `keyed_hash(key, message)` denotes keyed BLAKE2b-256 hash.
 
-Substrate primitives (i.e., block hashing) use BLAKE2b-256 as well. 
+Substrate primitives (i.e., block hashing) use BLAKE2b-256 as well.
 
 Proof-of-Space primitives use BLAKE3.
 
@@ -56,7 +56,7 @@ The leaf data for the Merkle Mountain Range contains the following fields:
 
 Fetches parent consensus block number and hash from the frame-system and fetch state root and extrinsic root through host function.
 
-### on_new_root 
+### on_new_root
 
 `on_new_root(mmr_root_hash)`
 
@@ -75,7 +75,7 @@ Returns the on-chain MMR root hash.
 
 Return the number of MMR blocks in the chain.
 
-### generate_proof 
+### generate_proof
 
 `generate_proof(block_numbers, best_known_block_number: Option)` -> `(Vec<Leaf>, Proof)`
 
@@ -90,11 +90,11 @@ same position in both the `leaves` vector and the leaf indices contained in the 
 
 ## Digital Signature
 
-Digital signatures secure different parts of consensus by providing a means of authentication. 
+Digital signatures secure different parts of consensus by providing a means of authentication.
 
 We currently use Schnorr/Ristretto x25519 (also known as sr25519) as the key derivation and signing algorithm (with the [schnorrkel](https://github.com/w3f/schnorrkel) library).
 
-Non-canonical Schnorr signatures are used to sign rewards for a newly forged block (as defined in Substrate) and votes by farmers, as well as transactions and transaction bundles by domain operators. 
+Non-canonical Schnorr signatures are used to sign rewards for a newly forged block (as defined in Substrate) and votes by farmers, as well as transactions and transaction bundles by domain operators.
 Canonical (deterministic) signatures are used as a verifiable random function (VRF) in the slot leader election among domain operators. A canonical scheme is necessary for these cases to prevent attackers from repeatedly signing until they produce an election solution that meets the threshold (as part of a grinding attack).
 
 ### sign
@@ -157,7 +157,7 @@ For a visual representation please see the figure below:
 
 <div align="center">
 
-![ETH KZG Ceremony](/img/Multi_Participants.png)
+![ETH KZG Ceremony](/static/img/Multi_Participants.png)
 
 </div>
 Further exploration of trusted setups can be found in [Vitalik Buterin's comprehensive post on trusted setups](https://vitalik.eth.limo/general/2022/03/14/trustedsetup.html).
@@ -229,7 +229,7 @@ Extends `source_commitments` vector so that the result is `1/rate` larger than t
 2. read from `aux` an evaluation domain of size double the `source_commitments` length
 3. evaluate that polynomial over that larger domain to obtain `extended_commitments` vector
 
-In the extended data (for both records and commitments), the values with even indices (i.e., (0,2,…,254)) correspond to the source values and the values with odd indices (i.e.,(1,3,…,255)) correspond to parity values. The source data is effectively contained only in values with an even index, making it sufficient to obtain only those for direct recovery. 
+In the extended data (for both records and commitments), the values with even indices (i.e., (0,2,…,254)) correspond to the source values and the values with odd indices (i.e.,(1,3,…,255)) correspond to parity values. The source data is effectively contained only in values with an even index, making it sufficient to obtain only those for direct recovery.
 
 ### recover_poly
 
@@ -247,13 +247,13 @@ The resulting `polynomial` is suitable for use with the KZG primitives `commit` 
 
 ## Encoding Mapping
 
-Encoding provides a means to make arbitrary useful data (i.e. chunks of blockchain history) look like random data through encoding, while allowing to retrieve the useful data through decoding. 
+Encoding provides a means to make arbitrary useful data (i.e. chunks of blockchain history) look like random data through encoding, while allowing to retrieve the useful data through decoding.
 
 `encode(data, key)` → `encoding`
 
 `decode(encoding, key)`  → `data`
 
-We currently use `XOR` as encoding function. The `key` in general may or may not depend on farmer public or private key. 
+We currently use `XOR` as encoding function. The `key` in general may or may not depend on farmer public or private key.
 
 ## Proof-of-Space
 
@@ -267,15 +267,15 @@ For the more detailed specification of these primitives see [Dilithium PoS Speci
 
 Initializes an amount of space larger than `PIECE_SIZE` by generating a [Chia plot table](https://www.chia.net/assets/Chia_Proof_of_Space_Construction_v1.1.pdf) from `seed` after forward propagation phase.
 
-Currently, the space parameter `k` is set to 20 with resulting in 160-byte *proofs-of-space*. 
+Currently, the space parameter `k` is set to 20 with resulting in 160-byte *proofs-of-space*.
 
 The plot seed is obtained from farmer public key, current sector and piece offset within the sector.
 
 
 <div align="center">
 
-![PoS Table Light](/img/PoS_Table-light.svg#gh-light-mode-only)
-![PoS Table Dark](/img/PoS_Table-dark.svg#gh-dark-mode-only)
+![PoS Table Light](/static/img/PoS_Table-light.svg#gh-light-mode-only)
+![PoS Table Dark](/static/img/PoS_Table-dark.svg#gh-dark-mode-only)
 
 </div>
 <center>Figure 1: Structure of Chia PoS table</center>
@@ -288,8 +288,8 @@ For a given `challenge_index` samples the `pos_table` for a valid full *proof-of
 
 <div align="center">
 
-![PoS Lookup Light](/img/PoS_Lookup-light.svg#gh-light-mode-only)
-![PoS Lookup Dark](/img/PoS_Lookup-dark.svg#gh-dark-mode-only)
+![PoS Lookup Light](/static/img/PoS_Lookup-light.svg#gh-light-mode-only)
+![PoS Lookup Dark](/static/img/PoS_Lookup-dark.svg#gh-dark-mode-only)
 
 </div>
 <center>Figure 2: Querying the PoS table at a challenge index. On average 37% of indices are missing a proof.</center>

--- a/docs/decex/xdm.md
+++ b/docs/decex/xdm.md
@@ -19,40 +19,40 @@ This document describes the current messaging protocol between domains in a trus
 ## Primitives
 
 ### Chain
-    
+
 A chain is a blockchain within the Subspace Network. A chain is identified as the Consensus chain or a Domain with a `DomainID`
-    
+
 ```rust
     pub enum ChainId {
         Consensus,
         Domain(DomainId),
     }
 ```
-    
+
 ### Domain
-    
+
 A Domain is a blockchain with some application modules. These applications act as senders and receivers of the messages using messaging protocol. A unique identifier identifies each application. Domain operators execute transactions bundled by other operators of the same domain when a new block is available.
-    
+
 ### Trusted third party
-    
+
 A trusted third party from the point of view of the domains is the consensus chain, the farmer network for block production. Domains use consensus chain to submit transaction bundles, verify the Message proofs of `domain_a` on `domain_b` and submit fraud proofs.
-    
+
 ### Channel
-    
-A Channel is a bi-directional connection between two domains. Channel connection is established when the `src_chain_id` initiates the channel connection open message, and  `dst_chain_id` responds with either approval or rejection. Once a connection is open, sending messages back and forth is possible. A Channel would be open until a maximum number of messages are sent. This could be configured or defaulted to the maximum possible value of the `Nonce` type. 
-    
-There is a deposit to open a channel between domains. Deposit should be high enough to discourage and make it economically inefficient to DDOS channel initiation connections between domains. 
-    
+
+A Channel is a bi-directional connection between two domains. Channel connection is established when the `src_chain_id` initiates the channel connection open message, and `dst_chain_id` responds with either approval or rejection. Once a connection is open, sending messages back and forth is possible. A Channel would be open until a maximum number of messages are sent. This could be configured or defaulted to the maximum possible value of the `Nonce` type.
+
+There is a deposit to open a channel between domains. Deposit should be high enough to discourage and make it economically inefficient to DDOS channel initiation connections between domains.
+
 A channel can be closed on either end by the channel owner. Once closed, the channel will stop sending and receiving any further messages. The Relayer will communicate to the other domain to close the channel and clean up.
-    
+
 A channel can be in one of the following states (`State`):
-    
+
 - `Initiated`: When a channel is initiated but has not received acknowledgment from the other domain.
 - `Open`: When a bi-directional channel is open to relay messages between domains.
 - `Closed`: When the channel is closed between the domains and stops receiving and sending new messages to the other domain.
-    
+
 A Channel is defined as follows
-    
+
 ```rust
     struct Channel {
     	// Unique channel identifier within DomainID namespace
@@ -74,40 +74,40 @@ A Channel is defined as follows
 	    maybe_owner: Option<AccountId>,
     }
 ```
-    
+
 ### Channel Inbox
-    
+
 All the incoming messages to the domain are validated and added to a pool before processing. If specific message arrived earlier than a previous message, it is stored until the previous message(s) is processed in the order of `Nonce`.
-    
+
 ### Channel Outbox
-    
-All messages originated from `src_chain_id` to a `dst_chain_id` will be added to this queue in the runtime state. 
-    
+
+All messages originated from `src_chain_id` to a `dst_chain_id` will be added to this queue in the runtime state.
+
 Messages stay in the outbox of `src_chain_id` until the domain block of `src_chain_id` containing the originating extrinsic is out of the challenge period or reached archiving depth (if `src_chain_id` is consensus chain).
-    
+
 There is also a notion of back pressure by limiting maximum number of messages queued `max_outgoing_messages` to outbox of `src_chain_id`. So when `dst_chain_id` doesn’t send any message responses, this should throttle the outbox until normal operation. Message is removed from the outbox once the message response is received from the `dst_chain_id`.
-    
+
 ### Channel Response Queue
-    
+
 All the message responses to the messages in the outbox are validated and added to this queue. The message responses are passed to the application units within the domain. If a response for message arrived earlier that previous message responses, then this response is stored until the previous message responses are delivered.
-    
+
 ### Channel Nonce
-    
+
 Channel nonce is used to order messages with in the channel and to avoid replay attacks.
-    
+
 A domain maintains 2 nonces for each domain and channel:
-    
+
 - `Incoming nonce`: This nonce is used to order the incoming messages to the domain through the channel from other domain. The nonce starts at 0 and is incremented after each received message.
 - `Outgoing nonce`: This nonce is used to order the outgoing messages from this domain to the other domains. The nonce starts at 0 and is incremented after every sent message.
 
 ### Message Proof
-    
+
 Message proof that can verify the validity of the message from the point-of-view of the consensus chain. Proof combines the storage proofs to validate messages.
-    
+
 The proof consists of the following components:
-    
+
 - MMR proof for the state root of the parent consensus block
-    
+
 ```rust
     pub struct MMRProof {
     	// consensus block number below archiving depth at which this MMR proof was generated
@@ -118,29 +118,29 @@ The proof consists of the following components:
     	proof,
     }
 ```
-    
+
 - Proof of the source domain state root and XDM inclusion in runtime
-    
+
 ```rust
     pub struct Proof<BlockNumber, BlockHash, StateRoot> {
       /// MMR proof, which provides the state root of consensus hash MMRProof,
       pub proof: MMRProof,
       /// Storage proof that src chain state_root is confirmed on Consensus chain.
       /// This is optional when the src_chain is Consensus.
-      pub domain_confirmed_proof: Option<StorageProof>, 
+      pub domain_confirmed_proof: Option<StorageProof>,
       /// Storage proof that message is processed on src_chain.
       pub message_proof: StorageProof,
     }
 ```
-    
+
 ### Message
-    
+
 Message encompasses the actual message being sent and metadata about the message itself. MessageID is a unique tuple of (`ChannelID` , `Nonce`). There are two types of Message payloads:
-    
+
 - `Protocol` payload, used by the protocol to open or close, acknowledge channel connection with other domain.
-        
+
 - `Endpoint` payload, used by the protocol to pass messages between endpoint on the `src` and `dst` domains.
-        
+
 ```rust
     pub struct Message<Balance> {
         /// Chain (consensus or domain id) that initiated this message.
@@ -157,49 +157,49 @@ Message encompasses the actual message being sent and metadata about the message
         pub last_delivered_message_response_nonce: Option<Nonce>,
     }
 ```
-    
+
 The response message follows the same structure except the `payload` contains either `Protocol(Response)` or `Endpoint(Response)`
-    
+
 ### Message Lifecycle
-    
+
 Conceptually, a message can be in one of the following states during its lifecycle:
-    
+
 From the POV of the sender `src_chain_id`:
 
 - Outboxed: A message-request is added to the outbox for the relayers to relay message to `dst_chain_id`. It stays in the outbox until the message-response is received.
 - Delivered: After message-response is received and executed, the message request is cleared from the outbox.
-    
+
 From the POV of the receiver `dst_chain_id`:
-    
+
 - Inboxed: A message-request is added to the inbox for the execution and response. It is not executed until the domain block of `src_chain_id` containing the originating extrinsic is out of the challenge period or reached archiving depth (if `src_chain_id` is consensus chain).
 - Cleared: After message-request is executed and message-response is constructed, the message-request is cleared from the inbox and message-response is added to the outbox.
 
 ### Relayer Component
-    
-A relayer component relays message from `src_chain_id` to `dst_chain_id`. Domain operators have builtin relayer to relay messages from the domain to other domains and the consensus chain. 
-    
-Operators on `domain_a` relay messages originating in `domain_a` to the consensus network and listen for messages destined to `domain_a` from any other domain. Messages are sent through the consensus network where all operators of all domains are present.
-    
-The payload for the extrinsic could be a message-request or a message-response.
-    
-### Fees
-    
-Fees are collected from the sender of the message on `src_chain_id` to pay for relay and execution of their message on both `src_chain_id` and `dst_chain_id` respectively.
-    
-Compute fees are computed based on adjusted weights of the exact calls performed on both `src_chain_id` and `dst_chain_id` in total. Since we need to account for the block fullness of each src and dst chain, we also include a constant multiplier, currently 5, to the final fee collected from the user. 
 
-Collected compute fees for the portion of execution happening on `src_chain_id` is paid to operators of `src_chain_id` and the compute fees for the portion of execution happening `dst_chain_id`. The portion of fees that is to be distributed on `dst_chain_id` is burned on `src_chain_id` when message is added to outbox.  
-    
+A relayer component relays message from `src_chain_id` to `dst_chain_id`. Domain operators have builtin relayer to relay messages from the domain to other domains and the consensus chain.
+
+Operators on `domain_a` relay messages originating in `domain_a` to the consensus network and listen for messages destined to `domain_a` from any other domain. Messages are sent through the consensus network where all operators of all domains are present.
+
+The payload for the extrinsic could be a message-request or a message-response.
+
+### Fees
+
+Fees are collected from the sender of the message on `src_chain_id` to pay for relay and execution of their message on both `src_chain_id` and `dst_chain_id` respectively.
+
+Compute fees are computed based on adjusted weights of the exact calls performed on both `src_chain_id` and `dst_chain_id` in total. Since we need to account for the block fullness of each src and dst chain, we also include a constant multiplier, currently 5, to the final fee collected from the user.
+
+Collected compute fees for the portion of execution happening on `src_chain_id` is paid to operators of `src_chain_id` and the compute fees for the portion of execution happening `dst_chain_id`. The portion of fees that is to be distributed on `dst_chain_id` is burned on `src_chain_id` when message is added to outbox.
+
 The burnt fees are subtracted from `src_chain_id` bookkeeping balance (if it’s a domain).
-    
+
 The relay fee is split equally among operators on `src_chain_id` and `dst_chain_id` who have submitted the ER that includes the message.
-    
+
 On the source chain, this reward is distributed when the message gets the response from the `dst_chain_id`. On the `dst_chain_id`, when it receives the next message, it will collect all the messages that are marked delivered on `src_chain_id`, mints the funds, and, distributes the rewards to the relayer pool on `dst_chain_id` for each message.
-    
+
 The minted fees are added to `dst_chain_id` bookkeeping balance (if it’s a domain).
-    
+
 **Outbox Message Fees**
-    
+
 1. User `sender` sends a message from `src_chain_id`
 2. `src_chain_id` collects `fees` to be paid by `sender` as follows:
     1. Compute fee for message execution on `dst_chain_id` with XDM multiplier included. This amount is burnt on `src_chain_id` and minted on `dst_chain_id` later.
@@ -207,9 +207,9 @@ The minted fees are added to `dst_chain_id` bookkeeping balance (if it’s a dom
 3. Message is sent to `dst_chain_id`.
 4. Once the response is received from `dst_chain_id`, `src_chain_id` distributes the rewards from `sender` to operators.
 5. This message nonce is sent to `dst_chain_id` as `last_delivered_message_response_nonce` as an acknowledgement so that it can reward its operators.
-    
+
 **Inbox Message Fees**
-    
+
 1. `dst_chain_id` receives a message from `src_chain_id`
 2. `dst_chain_id` mints received fees after message validation
 3. Message is processed and response is sent
@@ -229,11 +229,11 @@ The following describes the generic message from one domain to another. This mes
 8. Next message nonce is taken from the inbox of `dst_chain_id`.
 9. Message is executed and response is stored.
 10. Operator of `dst_chain_id` waits until the domain block with the message transaction is cleared from the challenge period before gossiping the message response.
-11. Message response on  `src_chain_id` is validated using storage proofs on the consensus chain.
+11. Message response on `src_chain_id` is validated using storage proofs on the consensus chain.
 12. Next Message response nonce is submitted to the endpoint and message is removed from the outbox of `src_chain_id`.
 13. When the `src_chain_id` prepares the next message, it will include the latest message nonce that was successful as part of the payload to notify `dst_chain_id` of message response acknowledgement.
 
-![XDM](/img/XDM.png)
+![XDM](/static/img/XDM.png)
 
 ## Networking
 
@@ -271,7 +271,7 @@ Similarly, each domain chain maintains its own `DomainChainAllowList` to keep tr
 3. If no Channel exits, Channel is created and set to `Initiated` status and cannot accept or receive any messages yet.
 4. When the channel is initiated, reserve deposit is taken from the channel and will be returned when Channel is closed.
 5. If the `src_chain_id` is not in the allow list of `dst_chain_id`, destination chain does not open a channel, but rather leaves it in `Initiated` state and responds with an `Err`. When the error response is received on source chain, it also does not open then channel and leaves it in the `Initiated` state.
-6. If both chains are in the allow list of each other, `Protocol` payload message to open the channel is added to the `src_chain_id` domain outbox with nonce `0` 
+6. If both chains are in the allow list of each other, `Protocol` payload message to open the channel is added to the `src_chain_id` domain outbox with nonce `0`
 
 ### Open Channel
 
@@ -280,7 +280,7 @@ Before sending any messages, domain needs to have a channel open with the `dst_c
 1. Channel is initiated by `src_chain_id` as described in [Initiate Channel](#initiate-channel)
 2. Operator on `dst_chain_id` receives a message with the corresponding `Protocol` `ChannelOpen` payload and `nonce=0`.
 3. Channel status is set to `Open` and a corresponding event is issued
-4. Operators on `dst_domain` submits the transaction with message response to `src_chain_id` 
+4. Operators on `dst_domain` submits the transaction with message response to `src_chain_id`
 5. `src_domain` moves the channel state to `Open` and starts accepting messages to be sent over channel
 
 ### Close Channel
@@ -292,12 +292,12 @@ Any domain of either end of an `Open` or `Initiated` channel can close the chann
 3. `Protocol` payload message to close channel is added to the `src_chain_id` outbox
 4. Operator on `src_chain_id` gossips the message
 5. Operator on `dst_chain_id` receives a message with the corresponding `Protocol` `ChannelClose` payload.
-6. Channel close response is submitted to `src_chain_id` 
+6. Channel close response is submitted to `src_chain_id`
 7. Channel reserve deposit is returned back to the channel owner once closed.
 
 ### Send message
 
-When user wants to send message from endpoint on `src_chain_id` to an endpoint on `dst_chain_id`  with an open channel to `dst_chain_id`.
+When user wants to send message from endpoint on `src_chain_id` to an endpoint on `dst_chain_id` with an open channel to `dst_chain_id`.
 
 1. User sends a transaction that results in a message to an endpoint on `dst_chain_id`.
 2. Transaction is included in the runtime state of `src_chain_id`.
@@ -331,7 +331,7 @@ Relayer from the `dst_chain_id` will submit the message response to the `src_cha
 1. `src_chain_id` verifies the message response and adds it to the message response queue.
 2. `src_chain_id` listens for next message response and submits the response to the caller module on the `src_chain_id`
 3. `src_chain_id` marks the message nonce as the last confirmed message which is included in the next message bound to `dst_chain_id`
-4. `src_chain_id` then deletes the state pertaining to the original message from the runtime. 
+4. `src_chain_id` then deletes the state pertaining to the original message from the runtime.
 
 ## XDM delays
 
@@ -357,7 +357,7 @@ At the moment, a maximum of 256 XDM messages per channel per chain are allowed t
 
 The XDM messages are prioritized over regular transactions.
 
-Example: If there are 2 channels between src and dst chain, Each of the chains will include at the most 256 * 2 XDM messages in a single block. 
+Example: If there are 2 channels between src and dst chain, Each of the chains will include at the most 256 * 2 XDM messages in a single block.
 
 ## Runtime calls
 
@@ -369,14 +369,14 @@ Listed in the order of call index in the runtime.
 
 Anyone can initiate a channel to `dst_chain` given both `dst_chain` and `src_chain` allow other chain to open channel.
 User would need to deposit fee to initiate channel open and the deposit is reversed once the channel is closed.
-Currently, for each channel, we set 10_000 maximum outgoing messages. 
+Currently, for each channel, we set 10_000 maximum outgoing messages.
 Once the channel reaches 10_000 pending XDM, it will not accept further messages until the pending XDMs are executed.
 
-Once the channel is initiated, `dst_chain` gets a message to open channel and reverts back to `src_chain` to confirm the 
+Once the channel is initiated, `dst_chain` gets a message to open channel and reverts back to `src_chain` to confirm the
 channel open. It would 2 challenge periods to open channel on both the chains. Once, both chains open channels, xdm messages can be sent through the channel.
 
-Note: Ensure both `src_chain` and `dst_chain` has other chain in their allowlist. 
-To add chain to the allowlist 
+Note: Ensure both `src_chain` and `dst_chain` has other chain in their allowlist.
+To add chain to the allowlist
 - To add a chain to Domain, use [Add `dst_chain` to Domain Allowlist](#add-dst_chain-to-domain-allowlist)
 - To add a chain to Consensus, use [Add `dst_chain` to Consensus Allowlist](#add-dst_chain-to-consensus-allowlist)
 
@@ -392,13 +392,13 @@ Once the channel is closed, no further xdm messages can be sent through the chan
 
 `update_consensus_chain_allowlist(update: ChainAllowlistUpdate,)`
 
-Only a sudo user can add `dst_chain` to the Consensus allowlist. Once the chain is added to the allow list, either 
+Only a sudo user can add `dst_chain` to the Consensus allowlist. Once the chain is added to the allow list, either
 `consensus chain` or `dst_chain` can initiate channel open.
 
 ### Add `dst_chain` to Domain allowlist
 
 `initiate_domain_update_chain_allowlist(domain_id: DomainId, update: ChainAllowlistUpdate)`
 
-Only a `src_domain` owner can add `dst_chain` to the `src_domain` allowlist. Once the `dst_chain` is added to the 
+Only a `src_domain` owner can add `dst_chain` to the `src_domain` allowlist. Once the `dst_chain` is added to the
 `src_domain` allowlist, either of the chains can initiate channel open. Ensure that `dst_chain` also included `src_domain`
 in its allow list.

--- a/docs/fees_and_rewards/Fees_and_Rewards.md
+++ b/docs/fees_and_rewards/Fees_and_Rewards.md
@@ -31,7 +31,7 @@ import Collapsible from '@site/src/components/Collapsible/Collapsible';
 
 <div align="center">
 
-![Fees & Rewards Specification Stack and Flow](/img/Fees_&_Rewards_Specification_Stack_and_flow.png)
+![Fees & Rewards Specification Stack and Flow](/static/img/Fees_&_Rewards_Specification_Stack_and_flow.png)
 
 </div>
 
@@ -96,7 +96,7 @@ Balance held by users who do not pledge storage and participate in consensus by 
 
 ## Dynamic Issuance
 
-As opposed to having a fixed issuance rate, the Subspace Network implements a dynamic issuance rate based on network usage, where, roughly, the inflation rate is inversely proportional to the utilization rate of the blockspace. 
+As opposed to having a fixed issuance rate, the Subspace Network implements a dynamic issuance rate based on network usage, where, roughly, the inflation rate is inversely proportional to the utilization rate of the blockspace.
 
 TLDR: The farmer who proposed a block gets some fresh SSC + fees, and voters get some fresh SSC regardless of what the proposer got.
 
@@ -123,7 +123,7 @@ $\text{storage fee per byte}  = \frac{\text{total credit supply}}{\text{total sp
 $\text{storage fee} \left(\text{tx}\right) = \text{storage fee per byte}*\text{length(tx)}\ shannons$
 </center>
 
-Implemented as 
+Implemented as
 <center>
 ```rust
 transaction_byte_fee = credit_supply / max(TotalSpacePledged / MinReplicationFactor - BlockchainHistorySize, 1)
@@ -137,7 +137,7 @@ A `transaction_byte_fee()` value computed on block finalization is persisted in 
 
 A compute fee (per weight unit) pays for the computational resources spent to execute the extrinsic.
 
-Compute fees for the execution of extrinsics on the consensus chain (e.g., balance transfers) are collected by the block proposer. 
+Compute fees for the execution of extrinsics on the consensus chain (e.g., balance transfers) are collected by the block proposer.
 Compute fees for executing transaction bundles on domains are paid to the domain operators who submit the Execution Receipt containing this bundle (split between all operators who submit this ER) after the ER has cleared the challenge period.
 
 - `WeightToFee` is the conversion rate of the weight to the native currency on the chain, currently used to calculate transaction execution fees. Currently set to 1 Shannon/weight unit (static, actual value TBD).
@@ -174,7 +174,7 @@ Storage fee for the bundle is received by the consensus block proposer (farmer) 
 
 **Price**
 
-The price for storage to be deducted is injected into the domain by an inherent extrinsic carrying the `transaction_byte_fee` for the next consensus block. 
+The price for storage to be deducted is injected into the domain by an inherent extrinsic carrying the `transaction_byte_fee` for the next consensus block.
 
 The storage fee that the domain charges to the sender of the transaction is higher (e.g., `domain_transaction_byte_fee > 2.4 * transaction_byte_fee` converted to SSC, currently 3x) than that determined by the consensus chain to make up for possible duplication of txs taking up blockspace.
 
@@ -203,7 +203,7 @@ The user is charged when the domain block that includes the bundle is executed.
 
 The `ER::block_fees` field stores the fees split by storage and compute fees (similar to how the consensus chain stores block fees). The fraud proof for this field  ([**Invalid Block Fees** ](docs/decex/fraud_proofs.md#invalid-block-fees)) handles both parts. The [**Inherent Extrinsic**](docs/decex/fraud_proofs.md#inherent-extrinsic) fraud proof variant handles the invalid inherent proof for `transaction_byte_fee`.
 
-When registering onto a domain, a percentage $s$ (currently 20%) of the operator’s stake is transferred to a “storage fee fund”. A `storage_fund_account` is a separate account from stake, derived uniquely from operator public key. The storage fee for a bundle $B$ will be paid from this account. 
+When registering onto a domain, a percentage $s$ (currently 20%) of the operator’s stake is transferred to a “storage fee fund”. A `storage_fund_account` is a separate account from stake, derived uniquely from operator public key. The storage fee for a bundle $B$ will be paid from this account.
 We can estimate the minimum operator stake required to be able to produce bundles for a challenge period.
 
 Any subsequent operator&nominator stake deposits will automatically allocate the same percentage $s$ to the `storage_fund_account`. Unlike staking deposits that are locked in the nominator account in `pallet_balances`, a % required for storage fees is transferred to `storage_fund_account` sub-account for this operator.
@@ -233,13 +233,13 @@ If the operator or nominator withdraws below minimum stake (or deregisters) they
 
 <div align="center">
 
-![Bundle Storage Fees](/img/Fees_&_Rewards_Specification_Bundle-st-fee.png)
+![Bundle Storage Fees](/static/img/Fees_&_Rewards_Specification_Bundle-st-fee.png)
 
 </div>
 
 **Refund**
 
-When the domain block containing the bundle is confirmed, the total storage fees (`total_storage_fees=ER::total_fees.storage_fees`) are refunded back to the `storage_fund_account`s of the operators who authored the bundles included in this block. 
+When the domain block containing the bundle is confirmed, the total storage fees (`total_storage_fees=ER::total_fees.storage_fees`) are refunded back to the `storage_fund_account`s of the operators who authored the bundles included in this block.
 
 Let `paid_storage` be the amount of fees this operator paid for their bundle and `total_paid_storage` be the total all operators paid in this block. Because `total_storage_fees` in this block does not necessarily equal `total_paid_storage` (may be more due to higher price on domain or less due to unaccounted duplication) we refund operators proportionally to what they have paid.
 
@@ -250,7 +250,7 @@ Let `paid_storage` be the amount of fees this operator paid for their bundle and
 
 
 Operator $O$ has staked 100 SSC with a minimum nominator stake of 10 SSC and nomination tax of 5%. Assume the storage fee reserve is 20%. The operator has to reserve 20 SSC for storage fees. Operator $O$ has 2 nominators $N_1 $ and $N_2$ each staked 50 SSC and reserved 20% = 10 SSC each for storage fees. Initially $\text{shares\_per\_ssc} = 1$, so $O$ gets 80 shares, and $N_1$ and $N_2$ each get 40 shares and $
-\text{total\_shares}=80+40+40=160$ in the stake and the same shares in the storage fee reserve. 
+\text{total\_shares}=80+40+40=160$ in the stake and the same shares in the storage fee reserve.
 
 Deposits:
 
@@ -258,14 +258,14 @@ Deposits:
 - $N_1$: `shares`=40, `storage_fee_deposit`=10 SSC
 - $N_2$: `shares`=40, `storage_fee_deposit`=10 SSC
 
-total shares: 160, 
-total stake: 160, 
-shares per ssc: 1, 
+total shares: 160,
+total stake: 160,
+shares per ssc: 1,
 storage fee fund balance:40
 
 
 In the next epoch, the pool has earned 20 SSC of compute fees and refunded an extra 4 SSC of storage fees, and the operator took 5% of compute fees as a commission (1 SSC). The pool stake is now$ 160+20=180$ SSC and storage reserve is now $40+4=44$ SSC.
-The pool end-of-epoch $\text{shares\_per\_ssc}$ is now $160/(160 + 20 * (1-0.05)) = 0.893855$. Notice that 4 SSC of storage fees do not count into current epoch rewards used for this calculation, which allows us to sustain our current assumptions of increasing share value despite fluctuating size of storage fee reserve. 
+The pool end-of-epoch $\text{shares\_per\_ssc}$ is now $160/(160 + 20 * (1-0.05)) = 0.893855$. Notice that 4 SSC of storage fees do not count into current epoch rewards used for this calculation, which allows us to sustain our current assumptions of increasing share value despite fluctuating size of storage fee reserve.
 If a new nominator $N_3$ stakes 67.2 SSC, 13.44 SSC will be reserved for storage fee fund, and the $\text{shares}$ they will get is $((67.2-13.44) * 0.893855) = 48$. The pool total stake becomes $181+53.76=234.76$ SSC, total shares $160+24+1$=209 and storage fee reserve 57.44 SSC.
 
 
@@ -276,9 +276,9 @@ Deposits:
 - $N_2$: `shares`=40, `storage_fee_deposit`=10 SSC
 - $N_3$: `shares`=48, `storage_fee_deposit`=13.44 SSC
 
-total shares: 209, 
-total stake: 234.76, 
-shares per ssc: 0.893855, 
+total shares: 209,
+total stake: 234.76,
+shares per ssc: 0.893855,
 storage fee fund balance: 57.44
 
 **Generic withdrawal formula:**
@@ -291,7 +291,7 @@ withdrawn from storage fee fund =
 `withdraw_shares/shares * storage_fee_deposit/total_storage_fee_deposits * storage_fee_fund_account_balance`
 
 The nominator’s known deposit is updated
-`storage_fee_deposit = storage_fee_deposit(1 - withdraw_shares/shares)` 
+`storage_fee_deposit = storage_fee_deposit(1 - withdraw_shares/shares)`
 `shares = shares-withdraw_shares`
 
 The total of all nominator deposits is updated
@@ -312,9 +312,9 @@ The total of all nominator deposits is updated
 
 The fund gets divided according to their deposit share (not stake share). Everyone gets their deposit back and little extra.
 
-Assume storage fund is $57.44$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$ 
+Assume storage fund is $57.44$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$
 
-$O$  gets $20.05/53.49*57.44=21.5$, 
+$O$  gets $20.05/53.49*57.44=21.5$,
 $N_1$ and $N_2$ both get $10/53.49*57.44=10.74$,
 $N_3$ gets $13.44/53.49*57.44=14.43$
 
@@ -322,15 +322,15 @@ $N_3$ gets $13.44/53.49*57.44=14.43$
 
 The fund gets divided according to their deposit share (not stake share). Everyone loses a bit.
 
-Assume storage fund is $50$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$ 
+Assume storage fund is $50$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$
 
-$O$ gets $20.05/53.49*50=18.74$, 
+$O$ gets $20.05/53.49*50=18.74$,
 $N_1$ and $N_2$ both get $10/53.49*50=9.35$,
 $N_3$ gets $13.44/53.49*50=12.56$
 
 **Scenario 3: Nominator completely unstakes, storage fee fund > $\sum$ deposits**
 
-Assume storage fund is $57.44$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$ 
+Assume storage fund is $57.44$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$
 
  $N_2$ unstakes and gets $10/53.49*57.44=10.74$
 
@@ -339,7 +339,7 @@ Everyone else can still withdraw more than they deposited.
 
 **Scenario 4: Nominator completely unstakes, storage fee fund < $\sum$ deposits**
 
-Assume storage fund is $50$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$ 
+Assume storage fund is $50$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$
 
  $N_2$ unstakes and gets $10/53.49*50=9.35$
 
@@ -348,7 +348,7 @@ Everyone shares proportional loss unless they wait for the fund to fill up.
 
 **Scenario 5: Nominator partially unstakes, storage fee fund > $\sum$ deposits**
 
-Assume storage fund is $57.44$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$ 
+Assume storage fund is $57.44$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$
 
  $N_2$ unstakes $15$ of their $40$ shares and gets $15/40*10/53.49*57.44=4$
 
@@ -357,11 +357,11 @@ Everyone else can still withdraw more than they deposited. $N_2$ has gained $0.2
 
 **Scenario 6: Nominator partially unstakes, storage fee fund < $\sum$ deposits**
 
-Assume storage fund is $50$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$ 
+Assume storage fund is $50$ and `total_storage_fee_deposits`=$(20.05 + 10 + 10 + 13.44)=53.49$
 
  $N_2$ unstakes $15$ of their $40$ shares and gets $15/40*10/53.49*50=3.5$
 
-$N_2$ known deposit is updated to `shares`$=40-15=25$ 
+$N_2$ known deposit is updated to `shares`$=40-15=25$
 `storage_fee_deposit`$=10*(1-15/40)=6.25$
 
 The storage fund becomes $46.5$ and `total_storage_fee_deposits`=$(20.05 + 10 + (1-15/40)*10 + 13.44)=49.74$


### PR DESCRIPTION
@dariolina Forgot to update the image paths in the documentation when migrating the images, which caused them to display incorrectly. This has now been fixed.

I also noticed a lot of unnecessary and odd spaces in the documentation, so I went ahead and formatted it as well.