### PR TITLE
Add EVM Runtime section and Transporter Precompile spec

### DIFF
--- a/docs/decex/evm_runtime/_category_.json
+++ b/docs/decex/evm_runtime/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "EVM Runtime",
+  "position": 9,
+  "link": {
+    "type": "generated-index",
+    "description": "How Subspace implements EVM runtime features."
+  }
+}

--- a/docs/decex/evm_runtime/permissioned_evm.md
+++ b/docs/decex/evm_runtime/permissioned_evm.md
@@ -9,8 +9,8 @@ keywords:
     - ethereum
     - permissioned
 last_update:
-  date: 04/14/2025
-  author: Teor
+  date: 10/15/2025
+  author: Jeremy Frank
 ---
 
 A "permissioned" Auto EVM instance uses an allow list to limit which users can create contracts.

--- a/docs/decex/evm_runtime/permissioned_evm.md
+++ b/docs/decex/evm_runtime/permissioned_evm.md
@@ -1,7 +1,7 @@
 ---
 title: Permissioned Auto EVM
 hide_title: false
-sidebar_position: 8
+sidebar_position: 1
 description: Autonomys permissioned Ethereum runtimes
 keywords:
     - runtime

--- a/docs/decex/evm_runtime/transporter_precompile.md
+++ b/docs/decex/evm_runtime/transporter_precompile.md
@@ -1,0 +1,118 @@
+---
+title: Transporter Precompile
+hide_title: false
+sidebar_position: 2
+description: Cross-domain token transfer precompile for Auto EVM
+keywords:
+  - precompile
+  - transporter
+  - cross-domain
+  - evm
+  - transfer
+last_update:
+  date: 10/15/2025
+  author: Jeremy Frank
+---
+
+The Transporter Precompile enables EVM smart contracts to transfer tokens from Auto EVM domains to the Autonomys consensus chain using the [Cross-Domain Messaging (XDM)](../xdm.md) protocol.
+
+## Core Functionality
+
+The Transporter Precompile is deployed at address `0x0000000000000000000000000000000000000800` and adds the following functionality:
+
+- Initiate transfers from the caller on an EVM domain to an AccountId32 on the consensus chain
+- Expose `minimum_transfer_amount()` to surface the current minimum transfer threshold
+
+## Goals
+
+- EVM-native UX: callable by EOAs and contracts like a regular Solidity interface.
+- Tooling interoperability: works with common EVM tooling without custom RPCs.
+- Observability: standardized `TransferToConsensus(address,bytes32,uint256)` event.
+
+### Interoperability with EVM tooling
+
+- Calling: use a Solidity interface (or ethers.js/web3.js ABI) targeting
+  `0x0000000000000000000000000000000000000800`.
+- Read-only: `minimum_transfer_amount()` supports `eth_call` for UI prechecks.
+- Events: indexers can decode with the event selector of
+  `keccak("TransferToConsensus(address,bytes32,u256)")`.
+
+## Functions
+
+### transfer_to_consensus_v1
+
+```solidity
+function transfer_to_consensus_v1(bytes32 receiver, uint256 amount) external
+```
+
+Transfers tokens from the calling EVM account to an AccountId32 on the consensus chain.
+
+**Parameters:**
+
+- `receiver` (bytes32): The AccountId32 of the recipient on the consensus chain
+- `amount` (uint256): The amount of tokens to transfer (in Shannon units)
+
+### minimum_transfer_amount
+
+```solidity
+function minimum_transfer_amount() external view returns (uint256)
+```
+
+Returns the minimum amount required for cross-domain transfers.
+
+## Events
+
+### TransferToConsensus
+
+```solidity
+event TransferToConsensus(address indexed sender, bytes32 indexed receiver, uint256 amount)
+```
+
+Emitted when a transfer to the consensus chain is initiated.
+
+**Parameters:**
+
+- `sender` (address indexed): The EVM address that initiated the transfer
+- `receiver` (bytes32 indexed): The consensus chain AccountId32 that will receive the tokens
+- `amount` (uint256): The amount of tokens transferred
+
+## Underlying Implementation
+
+The precompile wraps the `pallet-transporter` functionality, which:
+
+1. **Burns Tokens**: Uses the currency pallet to burn tokens from the sender's account
+2. **Creates Transfer Record**: Stores the transfer details in `OutgoingTransfers` storage
+3. **Sends Cross-Domain Message**: Uses the messenger system to communicate with the destination chain
+4. **Handles Confirmations**: Tracks transfer status and handles confirmations/failures
+
+## Usage Examples
+
+### Basic Transfer
+
+```solidity
+// Transfer 1000 tokens to consensus chain account
+bytes32 consensusAccount = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+uint256 amount = 1000 * 10**18; // Assuming 18 decimals
+
+ITransporter transporter = ITransporter(0x0000000000000000000000000000000000000800);
+transporter.transfer_to_consensus_v1(consensusAccount, amount);
+```
+
+### Check Minimum Amount
+
+```solidity
+ITransporter transporter = ITransporter(0x0000000000000000000000000000000000000800);
+uint256 minAmount = transporter.minimum_transfer_amount();
+
+// Only proceed if we meet the minimum
+if (amount >= minAmount) {
+    transporter.transfer_to_consensus_v1(receiver, amount);
+}
+```
+
+## Related Components
+
+- **pallet-transporter**: The underlying Substrate pallet that handles cross-domain transfers
+- **pallet-messenger**: Provides the cross-domain communication infrastructure
+- **EVM Domain Runtime**: Hosts the precompile and manages EVM execution
+- **Consensus Chain**: The destination for transfers initiated by this precompile

--- a/docs/decex/fraud_proofs.md
+++ b/docs/decex/fraud_proofs.md
@@ -1,6 +1,6 @@
 ---
 title: Fraud Proofs
-sidebar_position: 6
+sidebar_position: 7
 description: Proving fraudulent behavior on domains
 keywords:
     - execution
@@ -8,8 +8,8 @@ keywords:
     - fraud proof
     - challenge period
 last_update:
-  date: 10/03/2024
-  author: Dariia Porechna
+  date: 10/15/2025
+  author: Jeremy Frank
 ---
 import Collapsible from '@site/src/components/Collapsible/Collapsible';
 

--- a/docs/decex/staking_arithmetic_dust.md
+++ b/docs/decex/staking_arithmetic_dust.md
@@ -1,3 +1,13 @@
+---
+title: Staking Arithmetic Dust
+sidebar_position: 6
+description: Arithmetic dust in the staking protocol.
+keywords:
+  - staking
+  - arithmetic
+  - dust
+---
+
 # Arithmetic dust
 
 When doing fixed point fractional arithmetic, dust is inevitable due to limited accuracy.
@@ -37,12 +47,14 @@ The arithmetic in staking happens in 3 parts:
 ### The individual nominator
 
 Within an epoch, when a nominator deposits or withdraws, it keeps track of the deposited stake and the withdrawn shares. After the epoch transition, when the share price is available, it can:
+
 - Convert the deposited stake to shares, which it is entitled to withdraw later
 - Convert the withdrawn shares to stake, which it is entitled to unlock later
 
 ### The operator pool
 
 Within an epoch, the operator pool accumulates all the deposited stake in `deposits_in_epoch` and all the withdrawn shares in `withdrawals_in_epoch`. During epoch transition, it will add the reward (if any) to `current_total_stake` and then calculate a new share price as `current_total_shares / current_total_stake`. With this share price, it:
+
 - Converts the `deposits_in_epoch` to shares, and adds `deposits_in_epoch` and these shares to `current_total_stake` and `current_total_shares` respectively
 - Converts the `withdrawals_in_epoch` to stake, and adds `withdrawals_in_epoch` and this stake to `current_total_shares` and `current_total_stake` respectively
 
@@ -51,6 +63,7 @@ Within an epoch, the operator pool accumulates all the deposited stake in `depos
 NOTE: The unlock here refers to the nominator unlock after the operator is de-registered, this is different from the `unlock_funds` after withdraw.
 
 The unlock and slash can be seen as a variant of the nominator withdraw:
+
 - The nominator is fully withdrawing all its shares.
 - The shares are converted to stake based on the latest share price, and the shares and stake are removed from the operator pool's `current_total_shares` and `current_total_stake` directly (not through epoch transition).
 - For unlock, the stake is transferred to the nominator account. For slash, the stake is transferred to the treasury.
@@ -62,24 +75,28 @@ Arithmetic dust is inevitable for stake-share conversion since the share price i
 ### The operator pool convert `deposits_in_epoch` to share: rounding down
 
 If:
+
 - Rounding up, there are `D` more shares added to `current_total_shares`, essentially breaking `INVARIANT_1`.
 - Rounding down, there are `D` less shares added to `current_total_shares`, essentially giving out the dust as a reward to the pool and increasing the share price.
 
 ### The operator pool convert `withdrawals_in_epoch` to stake: rounding down
 
 If:
+
 - Rounding up, there are `D` more stakes removed from `current_total_stake`, essentially breaking `INVARIANT_1`.
 - Rounding down, there are `D` less stakes removed to `current_total_stake`, essentially leaving the dust as a reward to the pool and increasing the share price.
 
 #### The individual nominator converts deposited stake to share: rounding down
 
 If:
+
 - Rounding up, there are `D` more shares given out to the nominator, essentially breaking `INVARIANT_2`.
 - Rounding down, there are `D` less shares the nominator is entitled to withdraw, essentially leaving dust in the pool that will never be withdrawn, but will be given to the treasury after all nominators are unlocked.
 
 #### The individual nominator converts the withdrawn share to stake: rounding down
 
 If:
+
 - Rounding up, there are `D` more stake the nominator can unlock, essentially minting `D` stake out of thin air.
 - Rounding down, there are `D` less stake the nominator can unlock, essentially burning `D` stake.
 
@@ -88,6 +105,7 @@ If:
 ### Deposit: stake-to-share conversion
 
 Within a given epoch, assuming there are `n` nominators deposited `stake_1, .., stake_n` respectively. So:
+
 ```rust
 // For individual nominator:
 for stake_i in  stake_1, .., stake_n {
@@ -105,6 +123,7 @@ operator.current_total_shares += stake_to_share(deposits_in_epoch) - D
 Updating the deposited stake on both the individual nominator and the operator pool is pure addition, with no arithmetic dust. But updating shares is based on stake-to-share conversion, so the only connection between the nominator share and the `operator.current_total_shares` is that they use the same share price to convert deposited stake.
 
 For `INVARIANT_2` to hold:
+
 ```rust
 stake_to_share(deposits_in_epoch) - D >= sum(stake_to_share(stake_i)) - D_i)
 
@@ -138,6 +157,7 @@ operator.current_total_stake -= share_to_stake(withdrawals_in_epoch) - D
 Updating the withdrawn shares on both the individual nominator and the operator pool are pure subtraction, with no arithmetic dust. But updating the stake is based on the share-to-stake conversion, so the only connection between the nominator unlocked stake and the `operator.current_total_stake` is that they use the same share price to convert withdrawn shares.
 
 For `INVARIANT_3` to hold:
+
 ```rust
 share_to_stake(withdrawals_in_epoch) - D >= sum(share_to_stake(share_i)) - D_i)
 

--- a/docs/decex/xdm.md
+++ b/docs/decex/xdm.md
@@ -1,6 +1,6 @@
 ---
 title: Cross-Domain Messaging (XDM)
-sidebar_position: 7
+sidebar_position: 8
 description: Communication between domains and consensus chain
 keywords:
     - xdm
@@ -10,8 +10,8 @@ keywords:
     - cross-chain messaging
     - cross-domain messaging
 last_update:
-  date: 04/17/2025
-  author: Teor
+  date: 10/15/2025
+  author: Jeremy Frank
 ---
 
 This document describes the current messaging protocol between domains in a trusted code environment (permissioned runtime instantiation). This protocol describes messaging between the consensus chain and any domain and between two domains.


### PR DESCRIPTION
Summary of changes

- Introduce `docs/decex/evm_runtime/transporter_precompile.md` documenting the Transporter precompile.
- Add new EVM Runtime docs section (`docs/decex/evm_runtime/_category_.json`).
- Move Permissioned EVM doc into the EVM Runtime section.

